### PR TITLE
Fix "RuntimeError: CUDA Error: out of memory"

### DIFF
--- a/model.py
+++ b/model.py
@@ -72,9 +72,10 @@ def main():
         gt = torch.cat((gt, target), 0)
         bs, n_crops, c, h, w = inp.size()
         input_var = torch.autograd.Variable(inp.view(-1, c, h, w).cuda(), volatile=True)
-        output = model(input_var)
-        output_mean = output.view(bs, n_crops, -1).mean(1)
-        pred = torch.cat((pred, output_mean.data), 0)
+        with torch.no_grad(): # Fix CUDA out of memory
+          output = model(input_var)
+          output_mean = output.view(bs, n_crops, -1).mean(1)
+          pred = torch.cat((pred, output_mean.data), 0)
 
     AUROCs = compute_AUCs(gt, pred)
     AUROC_avg = np.array(AUROCs).mean()


### PR DESCRIPTION
# Problem
According to this [issue](https://github.com/arnoweng/CheXNet/issues/27)
I also forked this repo and try running on my Colab project. The same problem arose: `RuntimeError: CUDA Error: out of memory`.

# Solution
As far as my knowledge, the problem happened because some section did not require `grad` yet still did anyway. Thus, [`with no_grad()`](https://pytorch.org/docs/stable/generated/torch.no_grad.html) should be presented.